### PR TITLE
CollisionManagerのMaskListをvector から listに変更

### DIFF
--- a/Collision/CollisionManager.h
+++ b/Collision/CollisionManager.h
@@ -29,6 +29,7 @@ public:
             if (_id.compare(attributePair.first) == 0)
             {
                 result = ~attributePair.second;
+                break;
             }
         }
         for (std::string name : std::initializer_list<std::string>{ _ignoreNames... })
@@ -70,7 +71,7 @@ private:
     std::vector<Collider*> colliders_;
     std::vector<std::pair<std::string, std::string>> collisionNames_;
     std::vector<std::pair<std::string, uint32_t>> attributeList_;
-    std::vector<std::pair<std::string, uint32_t>> maskList_;
+    std::list<std::pair<std::string, uint32_t>> maskList_;
 
     void DebugWindow();
     void CheckCollisionPair(Collider* _colA, Collider* _colB);

--- a/External/ImGuiDebugManager/DebugManager.cpp
+++ b/External/ImGuiDebugManager/DebugManager.cpp
@@ -16,7 +16,7 @@ DebugManager::DebugManager()
 
 DebugManager::~DebugManager()
 {
-	
+
 }
 
 void DebugManager::DeleteComponent(const char* _strID)
@@ -55,7 +55,7 @@ void DebugManager::DrawUI()
 
 
 	ImGui::End();
-	
+
 
 	ImGui::PopID();
 #endif // _DEBUG
@@ -70,6 +70,7 @@ void DebugManager::ChangeFont()
 	fontcfg.OversampleH = 1;
 	fontcfg.PixelSnapH = 1;
 	fontcfg.GlyphOffset = ImVec2(0.0f, 0.0f);
+
 
 	ImFont* resultFont = io.Fonts->AddFontFromFileTTF(
 		"Resources/Font/NotoSansCJKjp-Light.ttf",

--- a/GameScene.cpp
+++ b/GameScene.cpp
@@ -51,6 +51,10 @@ void GameScene::Initialize()
     pPlayer_->RunSetMask();
 
     pCore_->RunSetMask();
+    pNestWallLeft_->RunSetMask();
+    pNestWallTop_->RunSetMask();
+    pNestWallRight_->RunSetMask();
+    pNestWallBottom_->RunSetMask();
 }
 
 void GameScene::Update()
@@ -83,6 +87,4 @@ void GameScene::MakeWall(NestWall** _nestWall, std::string _id, int _width, int 
     *_nestWall = new NestWall(_id);
     (*_nestWall)->SetRect(_width, _height, _origin);
     (*_nestWall)->Initialize();
-    pCollisionManager_->RegisterCollider((*_nestWall)->GetCollider());
-    (*_nestWall)->GetCollider()->SetAttribute(pCollisionManager_->GetNewAttribute("NestWall"));
 }

--- a/Object/Wall/NestWall.cpp
+++ b/Object/Wall/NestWall.cpp
@@ -7,7 +7,7 @@ NestWall::NestWall(std::string _ID)
 {
     id_ = _ID;
     DebugManager::GetInstance()->SetComponent(_ID.c_str(), std::bind(&NestWall::DebugWindow, this));
-    collider_.SetColliderID(id_);
+    pCollisionManager_ = CollisionManager::GetInstance();
 }
 
 NestWall::~NestWall()
@@ -17,7 +17,14 @@ NestWall::~NestWall()
 
 void NestWall::Initialize()
 {
+    collider_.SetColliderID("NestWall");
+    collider_.SetAttribute(pCollisionManager_->GetNewAttribute("NestWall"));
+    pCollisionManager_->RegisterCollider(&collider_);
+}
 
+void NestWall::RunSetMask()
+{
+    collider_.SetMask(pCollisionManager_->GetNewMask(collider_.GetColliderID(), "Player", "Core"));
 }
 
 void NestWall::Update()
@@ -42,7 +49,7 @@ void NestWall::DebugWindow()
 {
     auto pFunc = [&]()
     {
-        ImGuiTemplate::VariableTableRow("id_", id_.c_str());
+        ImGuiTemplate::VariableTableRow("id_", id_);
         ImGuiTemplate::VariableTableRow("rect_.LeftTop", rect_.LeftTop());
         ImGuiTemplate::VariableTableRow("rect_.RightBottom", rect_.RightBottom());
         ImGuiTemplate::VariableTableRow("collider_.GetCollisionAttribute", collider_.GetCollisionAttribute());

--- a/Object/Wall/NestWall.h
+++ b/Object/Wall/NestWall.h
@@ -4,6 +4,7 @@
 #include "BaseObject.h"
 #include "Collision/Collider.h"
 #include <string>
+#include "Collision/CollisionManager.h"
 
 class NestWall : public BaseObject
 {
@@ -13,6 +14,7 @@ public:
     ~NestWall();
 
     void Initialize();
+    void RunSetMask();
     void Update();
     void Draw();
 
@@ -23,6 +25,7 @@ private:
     std::string id_;
     Rect2 rect_;
     Collider collider_;
+    CollisionManager* pCollisionManager_;
 
     void DebugWindow();
 };

--- a/Player.cpp
+++ b/Player.cpp
@@ -41,7 +41,7 @@ void Player::Initialize()
 
 void Player::RunSetMask()
 {
-    collider_.SetMask(pCollisionManager_->GetNewMask(collider_.GetColliderID(), "Core"));
+    collider_.SetMask(pCollisionManager_->GetNewMask(collider_.GetColliderID(), "Core", "NestWall"));
 }
 
 void Player::Update()

--- a/imgui.ini
+++ b/imgui.ini
@@ -9,7 +9,7 @@ Size=658,119
 Collapsed=0
 
 [Window][Easing Parameters]
-Pos=0,0
+Pos=750,49
 Size=484,289
 Collapsed=0
 DockId=0x00000001,1
@@ -20,7 +20,7 @@ Size=343,755
 Collapsed=0
 
 [Window][デバッグ]
-Pos=0,0
+Pos=750,49
 Size=484,289
 Collapsed=0
 DockId=0x00000001,0
@@ -76,5 +76,5 @@ Column 0  Weight=1.0000
 Column 1  Weight=1.0000
 
 [Docking][Data]
-DockNode  ID=0x00000001 Pos=0,0 Size=484,289 Selected=0x435A4E3F
+DockNode  ID=0x00000001 Pos=750,49 Size=484,289 Selected=0x435A4E3F
 


### PR DESCRIPTION
vectorの再配置でメモリの配置が変更されるため
listに変更し防いだ。

NestWall同士の当たり判定の無効化(Maskの設定)