### PR TITLE
Shuku kan dan debug window

### DIFF
--- a/BaseObject.cpp
+++ b/BaseObject.cpp
@@ -8,7 +8,7 @@ void BaseObject::DebugWindow()
     /// DebugWindowがオーバーライドされていないときの
     /// デフォルトの動作を記述
 
-    DebugManager::GetInstance()->SetComponent(objectID_.c_str(), std::bind(&BaseObject::DebugWindow, this));
+    DebugManager::GetInstance()->SetComponent(objectID_, std::bind(&BaseObject::DebugWindow, this));
 
     auto pFunc = [&]()
     {

--- a/External/ImGuiDebugManager/DebugManager.cpp
+++ b/External/ImGuiDebugManager/DebugManager.cpp
@@ -140,7 +140,7 @@ void DebugManager::DrawUI()
 			if (parentID.compare("null-name") == 0) tabName = childID;
 			else tabName = parentID + childID;
 
-			if (enableTab && ImGui::BeginTabItem(tabName.c_str()))
+			if (enableTab && ImGui::BeginTabItem(tabName.c_str(), &enableTab))
 			{
 				std::string id_str = tabName + "TABITEM";
 				ImGui::PushID(id_str.c_str());

--- a/External/ImGuiDebugManager/DebugManager.cpp
+++ b/External/ImGuiDebugManager/DebugManager.cpp
@@ -19,13 +19,95 @@ DebugManager::~DebugManager()
 
 }
 
+void DebugManager::Window_ObjectList()
+{
+	ImGui::PushID("WindowObjectList");
+	if (ImGui::Begin("Objects"))
+	{
+		for (auto itr = componentList_.begin(); itr != componentList_.end();)
+		{
+			if (std::get<0>(*itr) == "null-name")
+			{
+				ImGui::Selectable(std::get<1>(*itr).c_str(), &std::get<3>(*itr));
+				itr++;
+			}
+			else // null-nameじゃないとき
+			{
+				std::string parentName = std::get<0>(*itr).c_str();
+				if (ImGui::TreeNode(parentName.c_str()))
+				{
+					do
+					{
+						//parentName = std::get<0>(*itr);
+						ImGui::Selectable(std::get<1>(*itr).c_str(), &std::get<3>(*itr));
+						itr++;
+						if (itr == componentList_.end()) break;
+					} while (std::get<0>(*itr) != "null-name");
+
+					ImGui::TreePop();
+				}
+				else
+				{
+					while (std::get<0>(*itr) != "null-name")
+					{
+						itr++;
+						if (itr == componentList_.end()) break;
+					}
+				}
+			}
+		}
+
+		ImGui::End();
+	}
+	ImGui::PopID();
+}
+
+std::list<std::tuple<std::string, std::string, const std::function<void(void)>, bool>>::iterator
+	DebugManager::GetInsertIterator(std::string _parentName)
+{
+	auto resultItr = std::find_if(
+		componentList_.begin(),
+		componentList_.end(),
+		[_parentName](std::tuple<std::string, std::string, const std::function<void()>, bool> arg) {
+		if (std::get<0>(arg).compare(_parentName) == 0)
+		{
+			return true;
+		}
+		return false;
+	});
+
+	if (resultItr == componentList_.end())
+	{
+		//return std::prev(resultItr);
+		return componentList_.begin();
+	}
+
+	do
+	{
+		resultItr++;
+		if (resultItr == componentList_.end())
+		{
+			return std::prev(resultItr);
+		}
+	} while (std::get<0>(*resultItr) == _parentName);
+
+	return resultItr;
+}
+
 void DebugManager::DeleteComponent(const char* _strID)
 {
-	componentList_.remove_if([_strID](std::pair<std::string, std::function<void(void)>> _component)
-		{
-			return _component.first.compare(_strID) == 0;
-		}
-	);
+	componentList_.remove_if([_strID](const auto& component) {
+		return std::get<0>(component).compare("null-name") == 0 &&
+			std::get<1>(component).compare(_strID) == 0;
+	});
+}
+
+void DebugManager::DeleteComponent(const char* _parentID, const char* _childID)
+{
+	componentList_.remove_if([_parentID, _childID](const auto& component) {
+		return std::get<0>(component).compare(_parentID) == 0 &&
+			std::get<1>(component).compare(_childID) == 0;
+	});
 }
 
 void DebugManager::DrawUI()
@@ -36,19 +118,36 @@ void DebugManager::DrawUI()
 
 	ImGui::PushID("DEBUG_MANAGER");
 
+	Window_ObjectList();
+
 	// デバッグウィンドウ描画
 	ImGui::Begin("デバッグ");
 
-	ImGui::BeginTabBar("## TABBAR");
+	ImGuiTabBarFlags flag = {};
+	flag |= ImGuiTabBarFlags_Reorderable;
+	flag |= ImGuiTabBarFlags_FittingPolicyResizeDown;
+	flag |= ImGuiTabBarFlags_TabListPopupButton;
+
+	ImGui::BeginTabBar("## TABBAR", flag);
 	for (auto& component : componentList_)
 	{
-		if (ImGui::BeginTabItem(component.first.c_str()))
+		// componentを展開 (参照)
+		auto& [parentID, childID, pFunc, enableTab] = component;
+
+		if (enableTab)
 		{
-			std::string id_str = component.first + "TABITEM";
-			ImGui::PushID(id_str.c_str());
-			component.second();
-			ImGui::PopID();
-			ImGui::EndTabItem();
+			std::string tabName;
+			if (parentID.compare("null-name") == 0) tabName = childID;
+			else tabName = parentID + childID;
+
+			if (enableTab && ImGui::BeginTabItem(tabName.c_str()))
+			{
+				std::string id_str = tabName + "TABITEM";
+				ImGui::PushID(id_str.c_str());
+				pFunc();
+				ImGui::PopID();
+				ImGui::EndTabItem();
+			}
 		}
 	}
 	ImGui::EndTabBar();

--- a/External/ImGuiDebugManager/DebugManager.h
+++ b/External/ImGuiDebugManager/DebugManager.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <functional>
-#include <utility>
 #include <list>
 #include <string>
+#include <tuple>
 
 #include "ImGuiTemplates.h"
 
@@ -17,8 +17,35 @@ public:
     DebugManager(DebugManager&&)                    = delete;
     DebugManager& operator=(const DebugManager&&)   = delete;
 
-    void SetComponent(const char* _strID, const std::function<void(void)>& _component) { componentList_.push_back({ _strID, _component }); }
+    /// <summary>
+    /// デバッグ用コンポーネントの登録
+    /// </summary>
+    /// <param name="_strID">タブに表示される名前</param>
+    /// <param name="_component">関数ポインタ。std::bindを使用することがほとんど</param>
+    void SetComponent(std::string _strID, const std::function<void(void)>& _component)
+    {
+        componentList_.push_back(std::make_tuple(std::string("null-name"), _strID, _component, false));
+    }
+
+    /// <summary>
+    /// デバッグ用コンポーネントの登録 (リスト用)
+    /// </summary>
+    /// <param name="_parentID">オブジェクトの種類</param>
+    /// <param name="_childID">オブジェクトの名前</param>
+    /// <param name="_component">関数ポインタ。std::bindを使用することがほとんど</param>
+    void SetComponent(std::string _parentID, std::string _childID, const std::function<void(void)>& _component)
+    {
+        componentList_.emplace(
+            GetInsertIterator(_parentID),
+            _parentID,
+            _childID,
+            _component,
+            false
+        );
+    }
+
     void DeleteComponent(const char* _strID);
+    void DeleteComponent(const char* _parentID, const char* _childID);
 
     void DrawUI();
     void ChangeFont();
@@ -27,5 +54,10 @@ private:
     DebugManager();
     ~DebugManager();
 
-    std::list<std::pair<std::string, std::function<void(void)>>> componentList_;
+    std::list<std::tuple<std::string, std::string, const std::function<void(void)>, bool>> componentList_;
+
+private:
+    void Window_ObjectList();
+    std::list<std::tuple<std::string,std::string,const std::function<void(void)>,bool>>::iterator
+        GetInsertIterator(std::string _parentName);
 };

--- a/GameScene.cpp
+++ b/GameScene.cpp
@@ -36,14 +36,14 @@ void GameScene::Initialize()
 
     pEnemy_ = new Enemy();
     pEnemy_->Initialize();
+    MakeWall(&pNestWallLeft_, "Left", 40, 720, { 0,0 });
 
     pCore_ = new Core();
     pCore_->Initialize();
 
-    MakeWall(&pNestWallLeft_, "NestWallLeft", 40, 720, { 0,0 });
-    MakeWall(&pNestWallTop_, "NestWallTop", 1280, 40, { 0,0 });
-    MakeWall(&pNestWallRight_, "NestWallRight", 40, 720, { 1240,0 });
-    MakeWall(&pNestWallBottom_, "NestWallBottom", 1280, 40, { 0,680 });
+    MakeWall(&pNestWallTop_, "Top", 1280, 40, { 0,0 });
+    MakeWall(&pNestWallRight_, "Right", 40, 720, { 1240,0 });
+    MakeWall(&pNestWallBottom_, "Bottom", 1280, 40, { 0,680 });
 
     static_cast<Enemy*>(pEnemy_)->SetTargetPosition(pPlayer_->GetWorldPosition());
 

--- a/Object/Wall/NestWall.cpp
+++ b/Object/Wall/NestWall.cpp
@@ -6,7 +6,7 @@
 NestWall::NestWall(std::string _ID)
 {
     objectID_ = _ID;
-    DebugManager::GetInstance()->SetComponent(_ID.c_str(), std::bind(&NestWall::DebugWindow, this));
+    DebugManager::GetInstance()->SetComponent("NestWall", _ID.c_str(), std::bind(&NestWall::DebugWindow, this));
     pCollisionManager_ = CollisionManager::GetInstance();
 }
 

--- a/imgui.ini
+++ b/imgui.ini
@@ -26,8 +26,8 @@ Collapsed=0
 DockId=0x00000001,0
 
 [Window][Objects]
-Pos=89,80
-Size=243,249
+Pos=10,9
+Size=125,289
 Collapsed=0
 
 [Table][0xF9180C93,5]
@@ -88,6 +88,18 @@ Column 1  Weight=1.0000
 Column 0  Weight=1.0000
 Column 1  Weight=1.0000
 
+[Table][0xD719A205,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0x3E7C3F71,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0x54341D3A,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
 [Docking][Data]
-DockNode  ID=0x00000001 Pos=793,62 Size=484,289 Selected=0xF66F1095
+DockNode  ID=0x00000001 Pos=793,62 Size=484,289 Selected=0x435A4E3F
 

--- a/imgui.ini
+++ b/imgui.ini
@@ -9,7 +9,7 @@ Size=658,119
 Collapsed=0
 
 [Window][Easing Parameters]
-Pos=767,236
+Pos=793,62
 Size=484,289
 Collapsed=0
 DockId=0x00000001,1
@@ -20,10 +20,15 @@ Size=343,755
 Collapsed=0
 
 [Window][デバッグ]
-Pos=767,236
+Pos=793,62
 Size=484,289
 Collapsed=0
 DockId=0x00000001,0
+
+[Window][Objects]
+Pos=89,80
+Size=243,249
+Collapsed=0
 
 [Table][0xF9180C93,5]
 RefScale=13
@@ -79,6 +84,10 @@ Column 1  Weight=1.0000
 Column 0  Weight=1.0000
 Column 1  Weight=1.0000
 
+[Table][0x5D45BCBF,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
 [Docking][Data]
-DockNode  ID=0x00000001 Pos=767,236 Size=484,289 Selected=0x435A4E3F
+DockNode  ID=0x00000001 Pos=793,62 Size=484,289 Selected=0xF66F1095
 


### PR DESCRIPTION
# やったこと

<!-- このプルリクエストにて何をしたのか？ -->
- ウィンドウ「Objects」からタブの追加・削除を可能にしました

## なぜそうしたのか

<!-- なぜこのプルリクエストが必要と考えたかについて説明があるとわかりやすい -->
- オブジェクトが増え、多数のタブが追加されることによって目的のタブにたどり着きにくくなってしまうから。

# 動作確認の有無

<!-- 動作確認しましたか？ -->
  - Yes

# その他補足 (optional)

<!-- 自由記述 -->
- SetComponent()をオーバーロードし、引数にparentIDを指定できるようになっています。