### PR TITLE
EnemyとぶつかったらCoreのHPを1減らす

### DIFF
--- a/Object/Core/Core.cpp
+++ b/Object/Core/Core.cpp
@@ -23,12 +23,17 @@ void Core::Initialize()
     pCollisionManager->RegisterCollider(&collider_);
     collider_.SetAttribute(pCollisionManager->GetNewAttribute("Core"));
 
+    hp_ = 3;
+
     std::vector<Vector2> temp = boxCore_.GetVertices();
     for (auto& v : temp)
     {
         v += position_;
     }
     collider_.SetVertices(std::move(temp));
+
+    // OnCollision関数を登録
+    collider_.SetOnCollision(std::bind(&Core::OnCollision, this, std::placeholders::_1));
 }
 
 void Core::RunSetMask()
@@ -52,12 +57,23 @@ void Core::Draw()
     );
 }
 
+void Core::OnCollision(const Collider* _other)
+{
+    if (_other->GetColliderID() == "Enemy")
+    {
+        hp_--;
+    }
+
+    if (hp_ < 0) hp_ = 0;
+}
+
 void Core::DebugWindow()
 {
     auto pFunc = [&]()
     {
         ImGuiTemplate::VariableTableRow("Attribute", collider_.GetCollisionAttribute());
         ImGuiTemplate::VariableTableRow("Mask", collider_.GetCollisionMask());
+        ImGuiTemplate::VariableTableRow("hp_", hp_);
     };
 
     ImGuiTemplate::VariableTable("Player", pFunc);

--- a/Object/Core/Core.h
+++ b/Object/Core/Core.h
@@ -16,6 +16,9 @@ public:
     void Update();
     void Draw();
 
+    // コールバック関数
+    void OnCollision(const Collider* _other);
+
     void DebugWindow();
 
     Collider* GetCollider() { return &collider_; }


### PR DESCRIPTION
# やったこと

<!-- このプルリクエストにて何をしたのか？ -->
- Enemyと衝突時、CoreのHPを1減らす(デフォルト値)

## なぜそうしたのか

<!-- なぜこのプルリクエストが必要と考えたかについて説明があるとわかりやすい -->
- 敵とぶつかったときCoreはHpを1減らし、Enemyは衝突時消える。

# 動作確認の有無

<!-- 動作確認しましたか？ -->
  - Yes

# その他補足 (optional)

<!-- 自由記述 -->
CoreからColliderを通じてEnemyを操作することはできないためEnemy内でCoreとぶつかったときの処理を記述する必要がある。