### PR TITLE
Shuku kan dan collision manager

### DIFF
--- a/Collision/Collider.h
+++ b/Collision/Collider.h
@@ -12,7 +12,7 @@ class CollisionManager;
 class Collider
 {
 public:
-    inline  BaseObject*                 GetOwner()                  const       { return owner_; }
+    inline  const BaseObject*           GetOwner()                  const       { return owner_; }
     inline  uint32_t                    GetCollisionAttribute()     const       { return collisionAttribute_; }
     inline  uint32_t                    GetCollisionMask()          const       { return *pCollisionMask_;}
     inline  Shape                       GetShape()                  const       { return shape_; }

--- a/Collision/Collider.h
+++ b/Collision/Collider.h
@@ -5,12 +5,14 @@
 #include <vector>
 #include <string>
 #include <functional>
+#include "BaseObject.h"
 
 class CollisionManager;
 
 class Collider
 {
 public:
+    inline  BaseObject*                 GetOwner()                  const       { return owner_; }
     inline  uint32_t                    GetCollisionAttribute()     const       { return collisionAttribute_; }
     inline  uint32_t                    GetCollisionMask()          const       { return *pCollisionMask_;}
     inline  Shape                       GetShape()                  const       { return shape_; }
@@ -18,6 +20,7 @@ public:
     inline  std::vector<Vector2>*       GetVertices()                           { return &verticesCollider_; }
     inline  const std::string&          GetColliderID()             const       { return colliderID_; }
 
+    inline  void                        SetOwner(BaseObject* _owner)            { owner_ = _owner; }
     inline  void                        SetColliderID(const std::string& _id)   { colliderID_ = _id; }
     void                                SetVertices(const std::vector<Vector2>&& _vertices);
     void                                SetVertices(const std::vector<Vector2>* _vertices);
@@ -36,6 +39,8 @@ public:
 private:
 
     std::function<void(const Collider*)> onCollisionFunction_;
+
+    BaseObject*             owner_              = nullptr;
 
     Shape                   shape_              = Shape::Polygon;
     std::string             colliderID_         = {};

--- a/Object/Core/Core.cpp
+++ b/Object/Core/Core.cpp
@@ -19,9 +19,6 @@ void Core::Initialize()
     pCollisionManager = CollisionManager::GetInstance();
     position_ = { 640, 360 };
     boxCore_.MakeSquare(30);
-    collider_.SetColliderID("Core");
-    pCollisionManager->RegisterCollider(&collider_);
-    collider_.SetAttribute(pCollisionManager->GetNewAttribute("Core"));
 
     hp_ = 3;
 
@@ -32,8 +29,21 @@ void Core::Initialize()
     }
     collider_.SetVertices(std::move(temp));
 
+    /// コライダー関連
+    // 所有者を登録
+    collider_.SetOwner(this);
+
+    // コライダー識別子を登録
+    collider_.SetColliderID("Core");
+
+    // アトリビュートの生成・登録
+    collider_.SetAttribute(pCollisionManager->GetNewAttribute("Core"));
+
     // OnCollision関数を登録
     collider_.SetOnCollision(std::bind(&Core::OnCollision, this, std::placeholders::_1));
+
+    // Colliderの登録
+    pCollisionManager->RegisterCollider(&collider_);
 }
 
 void Core::RunSetMask()

--- a/Object/Enemy/Enemy.cpp
+++ b/Object/Enemy/Enemy.cpp
@@ -23,6 +23,7 @@ void Enemy::Initialize()
     moveSpeed_ = 0.05f;
 
     pCollisionManager->RegisterCollider(&collider_);
+    collider_.SetOwner(this);
     collider_.SetAttribute(pCollisionManager->GetNewAttribute("Enemy"));
     //Colliderにポインタを渡す
     collider_.SetOnCollision(std::bind(&Enemy::OnCollision, this, std::placeholders::_1));

--- a/Object/Wall/NestWall.cpp
+++ b/Object/Wall/NestWall.cpp
@@ -25,6 +25,7 @@ void NestWall::Initialize()
 
     // コライダーにOnCollisionの関数ポインタを渡す
     collider_.SetOnCollision(std::bind(&NestWall::OnCollision, this, std::placeholders::_1));
+    collider_.SetOwner(this);
 }
 
 void NestWall::RunSetMask()

--- a/Player.cpp
+++ b/Player.cpp
@@ -31,12 +31,23 @@ void Player::Initialize()
     position_.x = 640.0f;
     position_.y = 360.0f;
     radius_current_ = radius_default_;
+
+    /// コライダー関連
+    // 所有者を登録
+    collider_.SetOwner(this);
+
+    // コライダー識別子を登録
     collider_.SetColliderID("Player");
 
-    pCollisionManager_->RegisterCollider(&collider_);
+    // アトリビュートの生成・登録
     collider_.SetAttribute(pCollisionManager_->GetNewAttribute("Player"));
-    //colliderにポインタを渡す
+
+    // colliderにポインタを渡す
     collider_.SetOnCollision(std::bind(&Player::OnCollision, this, std::placeholders::_1));
+
+    // colliderの登録
+    pCollisionManager_->RegisterCollider(&collider_);
+
 
     /// 回転板の初期化
     pRotateBoard_ = new RotateBoard();


### PR DESCRIPTION
# やったこと

<!-- このプルリクエストにて何をしたのか？ -->
- ColliderがColliderの所有者のポインタを所有するように変更

## なぜそうしたのか

<!-- なぜこのプルリクエストが必要と考えたかについて説明があるとわかりやすい -->
- コールバックのOnCollision関数の自由度が低いため各オブジェクトのメンバーも得られるようになったら使いやすいと考えたため。

# 動作確認の有無

<!-- 動作確認しましたか？ -->
  - Yes

# その他補足 (optional)

<!-- 自由記述 -->
GetOwnerはconst ポインタを返すため書き換えられる心配が少ない