### PR TITLE
Playerが攻撃をしているときだけ敵とプレイヤーの当たり判定をするように修正

### DIFF
--- a/Object/Enemy/Enemy.cpp
+++ b/Object/Enemy/Enemy.cpp
@@ -168,12 +168,15 @@ void Enemy::OnCollision(const Collider* _other)
     {
         if (!hasCollided_)                  // 初回の衝突時
         {
-            /// 向き反転
-            distanceToTarget    = -distanceToTarget;
-            rotation_           += 3.141592f;
+            if (static_cast<const Player*>(_other->GetOwner())->IsAttack())
+            {
+                /// 向き反転
+                distanceToTarget = -distanceToTarget;
+                rotation_ += 3.141592f;
 
-            isBouncing_         = true;     //ぶっ飛びフラグオン
-            hasCollided_        = true;     //衝突フラグオン
+                isBouncing_ = true;     //ぶっ飛びフラグオン
+                hasCollided_ = true;     //衝突フラグオン
+            }
         }
         /// 二回目以降の衝突は無視
 

--- a/Player.cpp
+++ b/Player.cpp
@@ -26,8 +26,8 @@ Player::~Player()
 void Player::Initialize()
 {
     startTime_ = std::chrono::system_clock::now();
-    pEasingBoxResize_ = std::make_unique<Easing>("DecreaseSize", Easing::EaseType::EaseOutCubic, 0.5);
-    pEasingBoxTemp_ = std::make_unique<Easing>("IncreaseSize", Easing::EaseType::EaseOutCubic, 0.5);
+    pEasingBoxResize_ = std::make_unique<Easing>("DecreaseSize");
+    pEasingBoxTemp_ = std::make_unique<Easing>("IncreaseSize");
 
     position_.x = static_cast<float>(DefaultSettings::kScreenWidth / 2ui32);
     position_.y = static_cast<float>(DefaultSettings::kScreenHeight / 2ui32);
@@ -75,6 +75,7 @@ void Player::Update()
 
     if (keys[DIK_SPACE])
     {
+        isAttack_ = false;
         if (radius_current_ > radius_min_)
         {
             pEasingBoxTemp_->Reset();
@@ -84,10 +85,13 @@ void Player::Update()
     }
     else if (!keys[DIK_SPACE] && preKeys[DIK_SPACE])
     {
+        /// スペースを離したら
         radius_timeRelease_ = radius_current_;
+        isAttack_ = true;
     }
     else
     {
+        if (pEasingBoxTemp_->GetIsEnd()) isAttack_ = false;
         pEasingBoxResize_->Reset();
         pEasingBoxTemp_->Start();
         radius_current_ = (1.0f - pEasingBoxTemp_->Update()) * radius_timeRelease_ + pEasingBoxTemp_->Update() * radius_default_;
@@ -143,6 +147,7 @@ void Player::DebugWindow()
     auto pFunc = [&]()
     {
         ImGuiTemplate::VariableTableRow("circle_", vertices_);
+        ImGuiTemplate::VariableTableRow("isAttack_", isAttack_);
         ImGuiTemplate::VariableTableRow("radius_current_", radius_current_);
         ImGuiTemplate::VariableTableRow("radius_timeRelease_", radius_timeRelease_);
         ImGuiTemplate::VariableTableRow("radius_default_", radius_default_);

--- a/Player.h
+++ b/Player.h
@@ -18,35 +18,38 @@ public:
     Player();
     ~Player();
 
-    void Initialize();
-    void RunSetMask();
-    void Update();
-    void Draw();
-    void SetEnableLighter(bool _flag) { collider_.SetEnableLighter(_flag); }
-    void OnCollision(const Collider* _other);
-    Collider* GetCollider() { return &collider_; }
+    void            Initialize();
+    void            RunSetMask();
+    void            Update();
+    void            Draw();
+    void            SetEnableLighter(bool _flag) { collider_.SetEnableLighter(_flag); }
+    bool            IsAttack() const { return isAttack_; }
+    void            OnCollision(const Collider* _other);
+    Collider*       GetCollider() { return &collider_; }
 
 private:
-    char keys[256]                  = {};
-    char preKeys[256]               = {};
+    char            keys[256]                   = {};
+    char            preKeys[256]                = {};
 
-    Collider collider_              = {};
-    RotateBoard* pRotateBoard_      = nullptr;
+    Collider        collider_                   = {};
+    RotateBoard*    pRotateBoard_               = nullptr;
+
+    float           radius_default_             = 100.0f;
+    float           radius_min_                 = 20.0f;
+    float           radius_current_             = 0.0f;
+    float           radius_timeRelease_         = 0.0f;
+
+    size_t          resolution_                 = 4u;
+    bool            isAttack_                   = false;
 
     std::vector<Vector2> vertices_  = {};
-
-    float radius_default_           = 100.0f;
-    float radius_min_               = 20.0f;
-    float radius_current_           = 0.0f;
-    float radius_timeRelease_       = 0.0f;
-
-    size_t resolution_              = 4u;
-
     std::chrono::system_clock::time_point startTime_;
     std::unique_ptr<Easing> pEasingBoxResize_;
     std::unique_ptr<Easing> pEasingBoxTemp_;
 
-private:
+private: /// 他オブジェクトから借りるデータ
     CollisionManager* pCollisionManager_;
+
+private: /// 非公開メソッド
     void DebugWindow();
 };


### PR DESCRIPTION
# やったこと

<!-- このプルリクエストにて何をしたのか？ -->
- タイトルに記載の通り

## なぜそうしたのか

<!-- なぜこのプルリクエストが必要と考えたかについて説明があるとわかりやすい -->
- 常に反射していて強かったから

# 動作確認の有無

<!-- 動作確認しましたか？ -->
  - Yes

# その他補足 (optional)

<!-- 自由記述 -->
