### PR TITLE
EnemyとNestwallの判定改善

### DIFF
--- a/Collision/CollisionManager.cpp
+++ b/Collision/CollisionManager.cpp
@@ -5,7 +5,7 @@
 
 void CollisionManager::Initialize()
 {
-    DebugManager::GetInstance()->SetComponent("CollisionManager", std::bind(&CollisionManager::DebugWindow, this));
+    DebugManager::GetInstance()->SetComponent("#Window", "CollisionManager", std::bind(&CollisionManager::DebugWindow, this));
 }
 
 void CollisionManager::CheckAllCollision()

--- a/External/ImGuiDebugManager/DebugManager.cpp
+++ b/External/ImGuiDebugManager/DebugManager.cpp
@@ -8,11 +8,11 @@
 
 DebugManager::DebugManager()
 {
-	ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 6.0f);
-	ImGui::PushStyleVar(ImGuiStyleVar_TabRounding, 0.0f);
-	ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.0f, 0.0f, 0.0f, 0.75f));
-	ImGui::PushStyleColor(ImGuiCol_TitleBgActive, ImVec4(0.8f, 0.1f, 0.1f, 0.75f));
-	ImGui::PushStyleColor(ImGuiCol_TitleBg, ImVec4(0.0f, 0.0f, 0.0f, 0.90f));
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 6.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_TabRounding, 0.0f);
+    ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.0f, 0.0f, 0.0f, 0.75f));
+    ImGui::PushStyleColor(ImGuiCol_TitleBgActive, ImVec4(0.8f, 0.1f, 0.1f, 0.75f));
+    ImGui::PushStyleColor(ImGuiCol_TitleBg, ImVec4(0.0f, 0.0f, 0.0f, 0.90f));
 }
 
 DebugManager::~DebugManager()
@@ -22,218 +22,223 @@ DebugManager::~DebugManager()
 
 void DebugManager::DebugWindowOverall()
 {
-	ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav;
+    ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav;
 
-	const float PAD = 10.0f;
-	const ImGuiViewport* viewport = ImGui::GetMainViewport();
-	ImVec2 work_pos = viewport->WorkPos; // Use work area to avoid menu-bar/task-bar, if any!
-	ImVec2 work_size = viewport->WorkSize;
-	ImVec2 window_pos, window_pos_pivot;
-	window_pos.x = PAD;
-	window_pos.y = PAD;
-	window_pos_pivot.x = 0.0f;
-	window_pos_pivot.y = 0.0f;
-	ImGui::SetNextWindowPos(window_pos, ImGuiCond_Always, window_pos_pivot);
-	ImGui::SetNextWindowViewport(viewport->ID);
-	window_flags |= ImGuiWindowFlags_NoMove;
+    const float PAD = 10.0f;
+    const ImGuiViewport* viewport = ImGui::GetMainViewport();
+    ImVec2 work_pos = viewport->WorkPos; // Use work area to avoid menu-bar/task-bar, if any!
+    ImVec2 work_size = viewport->WorkSize;
+    ImVec2 window_pos, window_pos_pivot;
+    window_pos.x = PAD;
+    window_pos.y = PAD;
+    window_pos_pivot.x = 0.0f;
+    window_pos_pivot.y = 0.0f;
+    ImGui::SetNextWindowPos(window_pos, ImGuiCond_Always, window_pos_pivot);
+    ImGui::SetNextWindowViewport(viewport->ID);
+    window_flags |= ImGuiWindowFlags_NoMove;
 
-	ImGui::SetNextWindowBgAlpha(0.0f);
+    ImGui::SetNextWindowBgAlpha(0.0f);
 
-	if (ImGui::Begin("Overray FPS", nullptr, window_flags))
-	{
-		ImGui::Text("%.2lfFPS", fps_);
-		ImGui::SameLine();
-		ImGui::ProgressBar(static_cast<float>(fps_) / 60.0f, ImVec2(0, 0), "");
+    if (ImGui::Begin("Overray FPS", nullptr, window_flags))
+    {
+        ImGui::Text("%.2lfFPS", fps_);
+        ImGui::SameLine();
+        ImGui::ProgressBar(static_cast<float>(fps_) / 60.0f, ImVec2(0, 0), "");
 
-		ImGui::EndPopup();
-	}
-	ImGui::End();
+        ImGui::EndPopup();
+    }
+    ImGui::End();
 }
 
 void DebugManager::MeasureFPS()
 {
-	if (!timer_.GetIsStart())
-	{
-		timer_.Start();
-	}
-	/// フレームレート計算
-	if (timer_.GetNow() - elapsedFrameCount_ >= 2.0)
-	{
-		fps_ = frameCount_ * 1.0 / (timer_.GetNow() - elapsedFrameCount_);
+    if (!timer_.GetIsStart())
+    {
+        timer_.Start();
+    }
+    /// フレームレート計算
+    if (timer_.GetNow() - elapsedFrameCount_ >= 2.0)
+    {
+        fps_ = frameCount_ * 1.0 / (timer_.GetNow() - elapsedFrameCount_);
 
-		frameCount_ = 0;
-		elapsedFrameCount_ = timer_.GetNow();
-	}
-	frameCount_++;
+        frameCount_ = 0;
+        elapsedFrameCount_ = timer_.GetNow();
+    }
+    frameCount_++;
 }
 
 void DebugManager::Window_ObjectList()
 {
-	ImGui::PushID("WindowObjectList");
-	if (ImGui::Begin("Objects"))
-	{
-		for (auto itr = componentList_.begin(); itr != componentList_.end();)
-		{
-			if (std::get<0>(*itr) == "null-name")
-			{
-				ImGui::Selectable(std::get<1>(*itr).c_str(), &std::get<3>(*itr));
-				itr++;
-			}
-			else // null-nameじゃないとき
-			{
-				std::string parentName = std::get<0>(*itr).c_str();
-				if (ImGui::TreeNode(parentName.c_str()))
-				{
-					do
-					{
-						//parentName = std::get<0>(*itr);
-						ImGui::Selectable(std::get<1>(*itr).c_str(), &std::get<3>(*itr));
-						itr++;
-						if (itr == componentList_.end()) break;
-					} while (std::get<0>(*itr) == parentName);
+    ImGui::PushID("WindowObjectList");
+    if (ImGui::Begin("Objects"))
+    {
+        for (auto itr = componentList_.begin(); itr != componentList_.end();)
+        {
+            if (std::get<0>(*itr) == "null-name")
+            {
+                ImGui::Selectable(std::get<1>(*itr).c_str(), &std::get<3>(*itr));
+                itr++;
+            }
+            else // null-nameじゃないとき
+            {
+                std::string parentName = std::get<0>(*itr).c_str();
+                if (ImGui::TreeNode(parentName.c_str()))
+                {
+                    do
+                    {
+                        //parentName = std::get<0>(*itr);
+                        ImGui::Selectable(std::get<1>(*itr).c_str(), &std::get<3>(*itr));
+                        itr++;
+                        if (itr == componentList_.end()) break;
+                    } while (std::get<0>(*itr) == parentName);
 
-					ImGui::TreePop();
-				}
-				else
-				{
-					while (std::get<0>(*itr) == parentName)
-					{
-						itr++;
-						if (itr == componentList_.end()) break;
-					}
-				}
-			}
-		}
-	}
-	ImGui::End();
-	ImGui::PopID();
+                    ImGui::TreePop();
+                }
+                else
+                {
+                    while (std::get<0>(*itr) == parentName)
+                    {
+                        itr++;
+                        if (itr == componentList_.end()) break;
+                    }
+                }
+            }
+        }
+    }
+    ImGui::End();
+    ImGui::PopID();
 }
 
 std::list<std::tuple<std::string, std::string, const std::function<void(void)>, bool>>::iterator
-	DebugManager::GetInsertIterator(std::string _parentName)
+    DebugManager::GetInsertIterator(std::string _parentName)
 {
-	auto resultItr = std::find_if(
-		componentList_.begin(),
-		componentList_.end(),
-		[_parentName](std::tuple<std::string, std::string, const std::function<void()>, bool> arg) {
-		if (std::get<0>(arg).compare(_parentName) == 0)
-		{
-			return true;
-		}
-		return false;
-	});
+    auto resultItr = std::find_if(
+        componentList_.begin(),
+        componentList_.end(),
+        [_parentName](std::tuple<std::string, std::string, const std::function<void()>, bool> arg) {
+        if (std::get<0>(arg).compare(_parentName) == 0)
+        {
+            return true;
+        }
+        return false;
+    });
 
-	if (resultItr == componentList_.end())
-	{
-		//return std::prev(resultItr);
-		return componentList_.begin();
-	}
+    if (resultItr == componentList_.end())
+    {
+        //return std::prev(resultItr);
+        return componentList_.begin();
+    }
 
-	do
-	{
-		resultItr++;
-		if (resultItr == componentList_.end())
-		{
-			return std::prev(resultItr);
-		}
-	} while (std::get<0>(*resultItr) == _parentName);
+    do
+    {
+        resultItr++;
+        if (resultItr == componentList_.end())
+        {
+            return std::prev(resultItr);
+        }
+    } while (std::get<0>(*resultItr) == _parentName);
 
-	return resultItr;
+    return resultItr;
 }
 
 void DebugManager::DeleteComponent(const char* _strID)
 {
-	componentList_.remove_if([_strID](const auto& component) {
-		return std::get<0>(component).compare("null-name") == 0 &&
-			std::get<1>(component).compare(_strID) == 0;
-	});
+    componentList_.remove_if([_strID](const auto& component) {
+        return std::get<0>(component).compare("null-name") == 0 &&
+            std::get<1>(component).compare(_strID) == 0;
+    });
 }
 
 void DebugManager::DeleteComponent(const char* _parentID, const char* _childID)
 {
-	componentList_.remove_if([_parentID, _childID](const auto& component) {
-		return std::get<0>(component).compare(_parentID) == 0 &&
-			std::get<1>(component).compare(_childID) == 0;
-	});
+    componentList_.remove_if([_parentID, _childID](const auto& component) {
+        return std::get<0>(component).compare(_parentID) == 0 &&
+            std::get<1>(component).compare(_childID) == 0;
+    });
 }
 
 void DebugManager::DrawUI()
 {
 #ifdef _DEBUG
 
-	if (!onDisplay_) return;
+    if (!onDisplay_) return;
 
-	MeasureFPS();
+    MeasureFPS();
 
-	DebugWindowOverall();
+    DebugWindowOverall();
 
-	// 登録されていないなら早期リターン
-	if (componentList_.size() == 0) return;
+    // 登録されていないなら早期リターン
+    if (componentList_.size() == 0) return;
 
-	ImGui::PushID("DEBUG_MANAGER");
+    ImGui::PushID("DEBUG_MANAGER");
 
-	Window_ObjectList();
+    Window_ObjectList();
 
-	// デバッグウィンドウ描画
-	ImGui::Begin("デバッグ");
+    // デバッグウィンドウ描画
+    ImGui::Begin("デバッグ");
 
-	ImGuiTabBarFlags flag = {};
-	flag |= ImGuiTabBarFlags_Reorderable;
-	flag |= ImGuiTabBarFlags_FittingPolicyResizeDown;
-	flag |= ImGuiTabBarFlags_TabListPopupButton;
+    ImGuiTabBarFlags flag = {};
+    flag |= ImGuiTabBarFlags_Reorderable;
+    flag |= ImGuiTabBarFlags_FittingPolicyResizeDown;
+    flag |= ImGuiTabBarFlags_TabListPopupButton;
 
-	ImGui::BeginTabBar("## TABBAR", flag);
-	for (auto& component : componentList_)
-	{
-		// componentを展開 (参照)
-		auto& [parentID, childID, pFunc, enableTab] = component;
+    ImGui::BeginTabBar("## TABBAR", flag);
+    for (auto& component : componentList_)
+    {
+        // componentを展開 (参照)
+        auto& [parentID, childID, pFunc, enableTab] = component;
 
-		if (enableTab)
-		{
-			std::string tabName;
-			if (parentID.compare("null-name") == 0) tabName = childID;
-			else tabName = parentID + childID;
+        if (enableTab)
+        {
+            std::string tabName;
+            if (parentID.compare("null-name") == 0) tabName = childID;
+            else tabName = parentID + childID;
 
-			if (enableTab && ImGui::BeginTabItem(tabName.c_str(), &enableTab))
-			{
-				std::string id_str = tabName + "TABITEM";
-				ImGui::PushID(id_str.c_str());
-				pFunc();
-				ImGui::PopID();
-				ImGui::EndTabItem();
-			}
-		}
-	}
-	ImGui::EndTabBar();
+            std::string id_str = tabName + "TABITEM";
+            ImGui::PushID(id_str.c_str());
+            if (enableTab && parentID.compare("#Window") == 0 && ImGui::Begin(childID.c_str(), &enableTab))
+            {
+                pFunc();
+                ImGui::End();
+            }
+            else if (enableTab && ImGui::BeginTabItem(tabName.c_str(), &enableTab))
+            {
+                pFunc();
+                ImGui::EndTabItem();
+            }
+            ImGui::PopID();
+        }
+    }
+    ImGui::EndTabBar();
 
 
-	ImGui::End();
+    ImGui::End();
 
 
-	ImGui::PopID();
+    ImGui::PopID();
 #endif // _DEBUG
 }
 
 void DebugManager::ChangeFont()
 {
-	ImGuiIO& io = ImGui::GetIO();
+    ImGuiIO& io = ImGui::GetIO();
 
-	ImFontConfig fontcfg;
-	fontcfg.MergeMode = 0;
-	fontcfg.OversampleH = 1;
-	fontcfg.PixelSnapH = 1;
-	fontcfg.GlyphOffset = ImVec2(0.0f, 0.0f);
+    ImFontConfig fontcfg;
+    fontcfg.MergeMode = 0;
+    fontcfg.OversampleH = 1;
+    fontcfg.PixelSnapH = 1;
+    fontcfg.GlyphOffset = ImVec2(0.0f, 0.0f);
 
 
-	ImFont* resultFont = io.Fonts->AddFontFromFileTTF(
-		"Resources/Font/NotoSansCJKjp-Light.ttf",
-		13,
-		&fontcfg,
-		io.Fonts->GetGlyphRangesJapanese()
-	);
+    ImFont* resultFont = io.Fonts->AddFontFromFileTTF(
+        "Resources/Font/NotoSansCJKjp-Light.ttf",
+        13,
+        &fontcfg,
+        io.Fonts->GetGlyphRangesJapanese()
+    );
 
-	io.FontDefault = resultFont;
+    io.FontDefault = resultFont;
 
-	io.Fonts->Build();
-	ImGui_ImplDX12_CreateDeviceObjects();
+    io.Fonts->Build();
+    ImGui_ImplDX12_CreateDeviceObjects();
 }

--- a/GameScene.cpp
+++ b/GameScene.cpp
@@ -168,7 +168,7 @@ void GameScene::DebugWindow()
         }
     }
 
-    if (ImGui::SmallButton("Delete All Enemies"))
+    if (ImGui::Button("Delete All Enemies"))
     {
         for (Enemy* enemy : enemyList_)
         {

--- a/Object/Enemy/Enemy.cpp
+++ b/Object/Enemy/Enemy.cpp
@@ -71,7 +71,7 @@ void Enemy::Update()
 
     Vector2 moveVelocity_ = {};
     // 衝突後の動き
-    if (isBouncing_) {
+    if (isBounce_) {
         // 反発する方向に移動
         velocity_ = distanceToTarget.Normalize() * bounceSpeed_;
     }
@@ -174,7 +174,7 @@ void Enemy::OnCollision(const Collider* _other)
                 distanceToTarget = -distanceToTarget;
                 rotation_ += 3.141592f;
 
-                isBouncing_ = true;     //ぶっ飛びフラグオン
+                isBounce_ = true;     //ぶっ飛びフラグオン
                 hasCollided_ = true;     //衝突フラグオン
             }
         }
@@ -187,7 +187,7 @@ void Enemy::OnCollision(const Collider* _other)
         // エネミーのデスフラグをオンに
         isDead_ = true;
     }
-    //敵同士の当たり判定
+    /// 敵同士の当たり判定
     else if (_other->GetColliderID() == "Enemy")
     {
         // 敵同士の位置を取得
@@ -203,6 +203,11 @@ void Enemy::OnCollision(const Collider* _other)
             // 反発速度を加える
             velocity_ = direction.Normalize() * bouncePower_enemy_;
         }
+    }
+    /// 巣壁との当たり判定
+    else if (_other->GetColliderID() == "NestWall")
+    {
+        isCollidedNest = true;
     }
 }
 

--- a/Object/Enemy/Enemy.h
+++ b/Object/Enemy/Enemy.h
@@ -36,18 +36,38 @@ public:
     void                            Draw();
 
 
+public: // Getter ===============
+
     /// <summary>
     /// コライダーを取得
     /// </summary>
     /// <returns>コライダーのポインタ</returns>
-    inline      const Collider*     GetCollider()
+    inline      const Collider*     GetCollider() const
     {
         return &collider_;
     }
 
 
-    void                            RunSetMask();
+    /// <summary>
+    /// プレイヤーによる攻撃を受けた後かどうか
+    /// </summary>
+    /// <returns>フラグ</returns>
+    inline      const bool          GetIsBounce() const
+    {
+        return isBounce_;
+    }
 
+
+    /// <summary>
+    /// すでに巣壁とぶつかったかどうか
+    /// </summary>
+    /// <returns>フラグ</returns>
+    inline      const bool          GetIsCollidedNest() const
+    {
+        return isCollidedNest;
+    }
+
+public: // Setter ===============
 
     /// <summary>
     /// ターゲットにする座標を指定
@@ -57,13 +77,6 @@ public:
     {
         positionTarget_ = _target;
     }
-
-
-    /// <summary>
-    /// 衝突時コールバック関数
-    /// </summary>
-    /// <param name="_other">衝突した相手のコライダー</param>
-    void                            OnCollision(const Collider* _other);
 
 
     /// <summary>
@@ -87,6 +100,19 @@ public:
     /// <param name="_flag">フラグ</param>
     void                            SetIsDead(bool _flag) { isDead_ = _flag; }
 
+
+public: // Others ===============
+
+    /// <summary>
+    /// 衝突時コールバック関数
+    /// </summary>
+    /// <param name="_other">衝突した相手のコライダー</param>
+    void                            OnCollision(const Collider* _other);
+
+
+    void                            RunSetMask();
+
+
 private: /// 非公開データ
     Collider                        collider_                   = {};           // コライダー
     Vector2                         vertices_[3]                = {};           // 三角形の頂点
@@ -106,7 +132,8 @@ private: /// 非公開データ
     char*                           preKeys_                    = nullptr;      // 前フレームのキー情報
 
     float                           bounceSpeed_                = 5.0f;         // 衝突時のぶっとび速度
-    bool                            isBouncing_                 = false;        // 跳ね返りフラグ
+    bool                            isBounce_                   = false;        // 跳ね返りフラグ
+    bool                            isCollidedNest              = false;        // ネストに攻撃したかどうか
 
     bool                            hasCollided_                = false;        // 衝突フラグ
     int32_t                         outScreenPadding_           = 0ui32;        // スクリーン外判定を行う範囲の余白

--- a/Object/Wall/NestWall.cpp
+++ b/Object/Wall/NestWall.cpp
@@ -2,6 +2,7 @@
 #include <Novice.h>
 #include "ImGuiDebugManager/DebugManager.h"
 #include "ImGuiTemplates.h"
+#include "Object/Enemy/Enemy.h"
 
 NestWall::NestWall(std::string _ID)
 {
@@ -47,7 +48,11 @@ void NestWall::OnCollision(const Collider* _collider)
 {
     if (_collider->GetColliderID() == "Enemy")
     {
-        hp_--;
+        const Enemy* pEnemy = static_cast<const Enemy*>(_collider->GetOwner());
+        if (pEnemy->GetIsBounce() && !pEnemy->GetIsCollidedNest())
+        {
+            hp_--;
+        }
     }
 
     if (hp_ < 0) hp_ = 0;

--- a/imgui.ini
+++ b/imgui.ini
@@ -9,10 +9,10 @@ Size=658,119
 Collapsed=0
 
 [Window][Easing Parameters]
-Pos=1022,72
-Size=502,352
+Pos=1027,68
+Size=502,173
 Collapsed=0
-DockId=0x00000001,0
+DockId=0x00000002,0
 
 [Window][DebugManager]
 Pos=937,0
@@ -20,13 +20,13 @@ Size=343,755
 Collapsed=0
 
 [Window][デバッグ]
-Pos=1022,72
-Size=502,352
+Pos=1027,68
+Size=502,173
 Collapsed=0
-DockId=0x00000001,1
+DockId=0x00000002,1
 
 [Window][Objects]
-Pos=305,216
+Pos=432,285
 Size=118,289
 Collapsed=0
 
@@ -34,6 +34,17 @@ Collapsed=0
 Pos=10,10
 Size=286,52
 Collapsed=0
+
+[Window][#WindowCollisionManager]
+Pos=1033,445
+Size=345,209
+Collapsed=0
+
+[Window][CollisionManager]
+Pos=1027,243
+Size=502,390
+Collapsed=0
+DockId=0x00000003,0
 
 [Table][0xF9180C93,5]
 RefScale=13
@@ -117,6 +128,16 @@ Column 1  Weight=1.0000
 Column 0  Weight=1.0000
 Column 1  Weight=1.0000
 
+[Table][0x42CF60DC,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
+[Table][0xC6356413,2]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+
 [Docking][Data]
-DockNode  ID=0x00000001 Pos=1022,72 Size=502,352 Selected=0xF66F1095
+DockNode    ID=0x00000001 Pos=1027,68 Size=502,565 Split=Y Selected=0x435A4E3F
+  DockNode  ID=0x00000002 Parent=0x00000001 SizeRef=502,173 Selected=0x435A4E3F
+  DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=502,390 Selected=0x0F8941E2
 


### PR DESCRIPTION
# やったこと

<!-- このプルリクエストにて何をしたのか？ -->
- 敵一体が巣壁にあたるごとにhp を 1 減らすように変更

## なぜそうしたのか

<!-- なぜこのプルリクエストが必要と考えたかについて説明があるとわかりやすい -->
- 敵が壁にあたっている間毎フレーム-1されていたため

# 動作確認の有無

<!-- 動作確認しましたか？ -->
  - Yes

# その他補足 (optional)

<!-- 自由記述 -->
